### PR TITLE
fixes: dataflow framework

### DIFF
--- a/crates/dataflow/src/analysis.rs
+++ b/crates/dataflow/src/analysis.rs
@@ -174,8 +174,9 @@ impl DataFlowEngine {
             iterations += 1;
 
             let block_id = worklist.pop().unwrap();
-            let (block_node, instructions) = cfg.basic_blocks().get(&block_id)
+            let block_node = cfg.basic_blocks().get(&block_id)
                 .ok_or_else(|| anyhow::anyhow!("Block {} not found", block_id.0))?;
+            let instructions = &block_node.instructions;
 
             let old_entry = entry_states.get(&block_id).cloned().unwrap_or_else(|| analysis.initial_state());
             let old_exit = exit_states.get(&block_id).cloned().unwrap_or_else(|| analysis.initial_state());
@@ -310,7 +311,7 @@ pub mod utils {
     /// Extract variable ID from an IR value if it's a variable
     pub fn extract_variable_id(value: &IrValue) -> Option<ValueId> {
         match value {
-            IrValue::Variable(id) => Some(*id),
+            IrValue::Value(id) => Some(*id),
             _ => None,
         }
     }
@@ -448,12 +449,12 @@ mod tests {
         let block2 = BlockId(2);
 
         let instructions1 = vec![
-            Instruction::Add(ValueId(1), IrValue::Constant(1), IrValue::Constant(2)),
-            Instruction::Sub(ValueId(2), IrValue::Variable(ValueId(1)), IrValue::Constant(1)),
+            Instruction::Add(ValueId(1), IrValue::ConstantInt(1), IrValue::ConstantInt(2)),
+            Instruction::Sub(ValueId(2), IrValue::Value(ValueId(1)), IrValue::ConstantInt(1)),
         ];
 
         let instructions2 = vec![
-            Instruction::Mul(ValueId(3), IrValue::Variable(ValueId(2)), IrValue::Constant(2)),
+            Instruction::Mul(ValueId(3), IrValue::Value(ValueId(2)), IrValue::ConstantInt(2)),
         ];
 
         cfg.add_block(block1, instructions1);

--- a/crates/dataflow/src/taint.rs
+++ b/crates/dataflow/src/taint.rs
@@ -527,7 +527,8 @@ impl<'a> TaintAnalysis<'a> {
     pub fn detect_violations(&self, result: &DataFlowResult<TaintState>) -> Vec<TaintViolation> {
         let mut violations = Vec::new();
 
-        for (block_id, instructions) in self.cfg.basic_blocks() {
+        for (block_id, block_node) in self.cfg.basic_blocks() {
+            let instructions = &block_node.instructions;
             if let Some(block_state) = result.get_exit_state(*block_id) {
                 for (instr_index, instruction) in instructions.iter().enumerate() {
                     if let Some(sink_name) = self.is_sink(instruction) {
@@ -733,14 +734,14 @@ mod tests {
 
         // Block 1: tainted_var = input, clean_var = 42
         let instructions1 = vec![
-            Instruction::Add(ValueId(1), IrValue::Parameter(0), IrValue::Constant(0)), // tainted_var = input
-            Instruction::Add(ValueId(2), IrValue::Constant(42), IrValue::Constant(0)), // clean_var = 42
+            Instruction::Add(ValueId(1), IrValue::Value(ValueId(0)), IrValue::ConstantInt(0)), // tainted_var = input
+            Instruction::Add(ValueId(2), IrValue::ConstantInt(42), IrValue::ConstantInt(0)), // clean_var = 42
         ];
 
         // Block 2: result = tainted_var + clean_var
         let instructions2 = vec![
-            Instruction::Add(ValueId(3), IrValue::Variable(ValueId(1)), IrValue::Variable(ValueId(2))), // result = tainted + clean
-            Instruction::Return(Some(IrValue::Variable(ValueId(3)))), // return result
+            Instruction::Add(ValueId(3), IrValue::Value(ValueId(1)), IrValue::Value(ValueId(2))), // result = tainted + clean
+            Instruction::Return(Some(IrValue::Value(ValueId(3)))), // return result
         ];
 
         cfg.add_block(block1, instructions1);


### PR DESCRIPTION
  Summary of Fixes Applied:

  1. Instruction Pattern Matching ✅

  - Fixed: Instruction::Branch(condition, _, _) → Instruction::ConditionalBranch(condition, _, _)
  in /crates/dataflow/src/def_use.rs:481
  - Reason: Branch takes only one parameter (target block), while ConditionalBranch takes three
  (condition, then_block, else_block)

  2. IrValue Enum Consistency ✅

  - Fixed: IrValue::Variable(id) → IrValue::Value(id) across all dataflow files
  - Fixed: IrValue::Constant(42) → IrValue::ConstantInt(42) across all dataflow files
  - Fixed: IrValue::Parameter(0) → IrValue::Value(ValueId(0)) in taint.rs
  - Reason: The actual enum definition uses Value, ConstantInt, etc., not the old naming

  3. Basic Blocks API Consistency ✅

  - Fixed: for (block_id, instructions) in cfg.basic_blocks() → for (block_id, block_node) in
  cfg.basic_blocks(); let instructions = &block_node.instructions;
  - Fixed: let (block_node, instructions) = cfg.basic_blocks().get(&block_id) → let block_node =
  cfg.basic_blocks().get(&block_id); let instructions = &block_node.instructions;
  - Reason: basic_blocks() returns HashMap<BlockId, &CfgNode>, and instructions are accessed via
  block_node.instructions

  Files Updated:

  - /crates/dataflow/src/analysis.rs
  - /crates/dataflow/src/def_use.rs
  - /crates/dataflow/src/taint.rs
  - /crates/dataflow/src/reaching_definitions.rs
  - /crates/dataflow/src/live_variables.rs

  These fixes ensure that the dataflow framework correctly interfaces with the IR instruction set
  and CFG APIs, resolving the compilation inconsistencies you identified. The code should now
  properly handle:

  - Correct instruction pattern matching for control flow
  - Consistent IrValue variant usage
  - Proper basic block API access patterns