### PR TITLE
fix test_single_line_replacement;

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ venv/
 .tmp/
 .temp/
 .claude
+debug_test
+debug_test*

--- a/crates/fixes/src/replacements.rs
+++ b/crates/fixes/src/replacements.rs
@@ -492,7 +492,7 @@ mod tests {
         };
 
         let result = engine.apply_replacements(source, &[replacement]).unwrap();
-        assert_eq!(result, "line 1\nNEW 2\nline 3");
+        assert_eq!(result, "line 1\nNEW2\nline 3");
     }
 
     #[test]


### PR DESCRIPTION
  1. Root Cause: The test test_single_line_replacement had an incorrect expectation.
  2. Analysis: The replacement logic uses 1-based column numbers where end_column represents the
  first column NOT to include (exclusive range). With start_column=1, end_column=6:
    - Replace columns 1-5 = "line " (including the space)
    - Keep columns 6+ = "2"
    - Correct result = "NEW2"
  3. Fix: Updated the test expectation from "line 1\nNEW 2\nline 3" to "line 1\nNEW2\nline 3" in
  /Users/pwner/Git/ABS/SolidityDefend/crates/fixes/src/replacements.rs:495
  4. Verification: The fix maintains consistency with the existing test_multiple_replacements test
  which uses the same column semantics correctly.