### PR TITLE
fixed major compilation warnings

### DIFF
--- a/crates/cfg/src/analysis.rs
+++ b/crates/cfg/src/analysis.rs
@@ -38,7 +38,7 @@ impl<'a> CfgAnalysisEngine<'a> {
         self.loop_analysis = Some(loop_analysis);
 
         // Analyze basic blocks
-        let block_analyzer = BasicBlockAnalyzer::new();
+        let _block_analyzer = BasicBlockAnalyzer::new();
         // For this to work, we'd need to convert from ControlFlowGraph to IrFunction
         // For now, we'll create a placeholder
         let block_info = BasicBlockInfo {

--- a/crates/cfg/src/blocks.rs
+++ b/crates/cfg/src/blocks.rs
@@ -6,6 +6,7 @@ use ir::{IrFunction, BlockId, Instruction, BasicBlock};
 /// Basic block identification and analysis utilities
 pub struct BasicBlockAnalyzer {
     /// Options for basic block analysis
+    #[allow(dead_code)]
     options: BasicBlockOptions,
 }
 
@@ -80,7 +81,7 @@ impl BasicBlockAnalyzer {
         leaders.insert(ir_function.entry_block);
 
         // Find targets of branches
-        for (block_id, basic_block) in &ir_function.basic_blocks {
+        for (_block_id, basic_block) in &ir_function.basic_blocks {
             for instruction in &basic_block.instructions {
                 match instruction {
                     Instruction::Branch(target) => {

--- a/crates/cfg/src/builder.rs
+++ b/crates/cfg/src/builder.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, HashSet};
-use anyhow::{Result, anyhow};
+use std::collections::HashSet;
+use anyhow::Result;
 
-use ir::{IrFunction, BlockId, Instruction, IrValue, ValueId};
+use ir::{IrFunction, BlockId, Instruction};
 use crate::graph::{ControlFlowGraph, EdgeType};
 
 /// Builder for constructing Control Flow Graphs from IR functions
@@ -136,8 +136,8 @@ impl CfgBuilder {
     /// Add fall-through edge for blocks without explicit control flow
     fn add_fall_through_edge(
         &self,
-        cfg: &mut ControlFlowGraph,
-        block_id: BlockId,
+        _cfg: &mut ControlFlowGraph,
+        _block_id: BlockId,
         _basic_block: &ir::BasicBlock
     ) -> Result<()> {
         // For now, we don't add implicit fall-through edges

--- a/crates/cfg/src/dominance.rs
+++ b/crates/cfg/src/dominance.rs
@@ -105,8 +105,8 @@ impl DominatorTree {
     /// Intersect two nodes in the dominator tree
     fn intersect(&self, mut b1: BlockId, mut b2: BlockId, blocks: &[BlockId]) -> Result<BlockId> {
         // Get the reverse postorder numbers for comparison
-        let b1_rpo = self.get_reverse_postorder_number(b1, blocks);
-        let b2_rpo = self.get_reverse_postorder_number(b2, blocks);
+        let _b1_rpo = self.get_reverse_postorder_number(b1, blocks);
+        let _b2_rpo = self.get_reverse_postorder_number(b2, blocks);
 
         while b1 != b2 {
             let b1_rpo_current = self.get_reverse_postorder_number(b1, blocks);

--- a/crates/cfg/src/graph.rs
+++ b/crates/cfg/src/graph.rs
@@ -6,7 +6,7 @@ use petgraph::visit::EdgeRef;
 use anyhow::{Result, anyhow};
 use serde::{Serialize, Deserialize};
 
-use ir::{BlockId, BasicBlock, IrFunction, Instruction};
+use ir::{BlockId, Instruction};
 
 /// Control Flow Graph using petgraph for efficient graph operations
 #[derive(Debug, Clone)]

--- a/crates/db/src/database.rs
+++ b/crates/db/src/database.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 use std::collections::HashMap;
-use std::sync::Arc;
 use sha2::{Sha256, Digest};
 use anyhow::{Result, anyhow};
 use serde::{Serialize, Deserialize};
@@ -286,7 +285,7 @@ impl Database {
         total += self.arena.allocated_bytes();
 
         // File registry memory
-        for (file_id, input) in &self.file_registry {
+        for (_file_id, input) in &self.file_registry {
             // SourceFileId overhead
             total += std::mem::size_of::<SourceFileId>();
 
@@ -312,7 +311,7 @@ impl Database {
         total += std::mem::size_of::<HashMap<SourceFileId, SourceFileInput>>();
 
         // Cache memory
-        for (file_id, result) in &self.cache {
+        for (_file_id, result) in &self.cache {
             // Key overhead
             total += std::mem::size_of::<SourceFileId>();
 

--- a/crates/db/src/queries.rs
+++ b/crates/db/src/queries.rs
@@ -4,8 +4,6 @@
 /// that are called by the Salsa framework for incremental computation.
 
 use anyhow::Result;
-use std::sync::Arc;
-use ast::SourceFile;
 use crate::database::{Database, SourceFileId};
 
 /// Helper function to extract functions from a database query result

--- a/crates/detectors/src/access_control.rs
+++ b/crates/detectors/src/access_control.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use std::any::Any;
 
 use crate::detector::{Detector, DetectorCategory, BaseDetector};
-use crate::types::{DetectorId, Finding, AnalysisContext, Severity, Confidence};
+use crate::types::{DetectorId, Finding, AnalysisContext, Severity};
 
 /// Detector for missing access control modifiers on critical functions
 pub struct MissingModifiersDetector {

--- a/crates/detectors/src/detector.rs
+++ b/crates/detectors/src/detector.rs
@@ -271,6 +271,7 @@ impl BaseDetector {
 }
 
 /// Macro to help implement the Detector trait for structs that contain BaseDetector
+#[allow(unused_macros)]
 macro_rules! impl_detector_base {
     ($struct_name:ty) => {
         impl Detector for $struct_name {

--- a/crates/detectors/src/logic/division_order.rs
+++ b/crates/detectors/src/logic/division_order.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use ast;
 
 use crate::detector::{Detector, DetectorCategory, BaseDetector, AstAnalyzer};
-use crate::types::{DetectorId, Finding, AnalysisContext, Severity, Confidence};
+use crate::types::{DetectorId, Finding, AnalysisContext, Severity};
 
 /// Detector for division before multiplication which causes precision loss
 pub struct DivisionOrderDetector {

--- a/crates/detectors/src/types.rs
+++ b/crates/detectors/src/types.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use anyhow::Result;
-
-use ast::{Contract, Function, Statement, Expression, Modifier};
+use ast::{Contract, Function, Modifier};
 use semantic::SymbolTable;
 // Temporarily disabled due to CFG compilation errors
 // use cfg::ControlFlowGraph;

--- a/crates/detectors/src/validation/array_bounds.rs
+++ b/crates/detectors/src/validation/array_bounds.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use ast::{self, Located};
 
 use crate::detector::{Detector, DetectorCategory, BaseDetector, AstAnalyzer};

--- a/crates/detectors/src/validation/parameter_check.rs
+++ b/crates/detectors/src/validation/parameter_check.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use ast;
 
 use crate::detector::{Detector, DetectorCategory, BaseDetector, AstAnalyzer};

--- a/crates/ir/src/lowering.rs
+++ b/crates/ir/src/lowering.rs
@@ -142,7 +142,7 @@ impl Lowering {
         }
 
         // Create IR function
-        let mut ir_function = IrFunction::new(
+        let ir_function = IrFunction::new(
             function.name.name.to_string(),
             ir_parameters,
             ir_return_types,
@@ -593,7 +593,7 @@ impl Lowering {
                 }
 
                 // Determine function name and type
-                let (func_name, is_external) = match function {
+                let (func_name, _is_external) = match function {
                     Expression::Identifier(id) => (id.name.to_string(), false),
                     Expression::MemberAccess { expression, member, .. } => {
                         // External call: contract.function()
@@ -644,11 +644,11 @@ impl Lowering {
                     ElementaryType::Address => IrType::Address,
                     ElementaryType::Uint(bits) => IrType::Uint(*bits),
                     ElementaryType::Int(bits) => IrType::Int(*bits),
-                    ElementaryType::Fixed(bits, decimals) => {
+                    ElementaryType::Fixed(bits, _decimals) => {
                         // For now, treat as uint
                         IrType::Uint(*bits)
                     }
-                    ElementaryType::Ufixed(bits, decimals) => {
+                    ElementaryType::Ufixed(bits, _decimals) => {
                         // For now, treat as uint
                         IrType::Uint(*bits)
                     }

--- a/crates/parser/src/arena.rs
+++ b/crates/parser/src/arena.rs
@@ -19,7 +19,7 @@ impl<'arena> ArenaParser<'arena> {
     /// Parse Solidity source code into arena-allocated AST
     pub fn parse(&self, source: &str, file_path: &str) -> Result<SourceFile<'arena>, ParseErrors> {
         // Parse using solang-parser
-        let (parse_tree, comments) = match parse(source, Self::DEFAULT_FILE_ID) {
+        let (parse_tree, _comments) = match parse(source, Self::DEFAULT_FILE_ID) {
             Ok((tree, comments)) => (tree, comments),
             Err(errors) => {
                 let mut parse_errors = ParseErrors::new();
@@ -134,10 +134,10 @@ impl<'arena> ArenaParser<'arena> {
                         }
                     }
                 }
-                pt::ContractPart::VariableDefinition(var) => {
+                pt::ContractPart::VariableDefinition(_var) => {
                     // TODO: Convert state variables
                 }
-                pt::ContractPart::EventDefinition(event) => {
+                pt::ContractPart::EventDefinition(_event) => {
                     // TODO: Convert events
                 }
                 // pt::ContractPart::ModifierDefinition(modifier) => {
@@ -187,6 +187,7 @@ impl<'arena> ArenaParser<'arena> {
     }
 
     /// Convert solang identifier to our Identifier
+    #[allow(dead_code)]
     fn convert_identifier(
         &self,
         ident: &pt::Identifier,
@@ -211,6 +212,7 @@ impl<'arena> ArenaParser<'arena> {
     }
 
     /// Convert solang location to our SourceLocation
+    #[allow(dead_code)]
     fn convert_location(&self, loc: &pt::Loc, file_path: &str) -> SourceLocation {
         self.convert_location_with_source(loc, file_path, None)
     }

--- a/crates/semantic/src/inheritance.rs
+++ b/crates/semantic/src/inheritance.rs
@@ -5,7 +5,7 @@ use petgraph::visit::{EdgeRef, IntoNodeReferences};
 use anyhow::{Result, anyhow};
 
 use ast::{Contract, InheritanceSpecifier, SourceLocation, ContractType};
-use crate::symbols::{SymbolTable, Scope, Symbol, SymbolKind};
+use crate::symbols::{SymbolTable, Scope};
 
 /// Node data for the inheritance graph
 #[derive(Debug, Clone, PartialEq)]
@@ -252,7 +252,7 @@ impl InheritanceGraph {
     /// Get the linearized inheritance order (C3 linearization) for a contract
     /// This determines the order in which parent contracts are considered for method resolution
     pub fn get_linearized_inheritance(&self, contract_name: &str) -> Result<Vec<String>> {
-        let node_index = self.name_to_node.get(contract_name)
+        let _node_index = self.name_to_node.get(contract_name)
             .ok_or_else(|| anyhow!("Contract '{}' not found", contract_name))?;
 
         // Simplified linearization - in practice, should implement C3 linearization
@@ -379,6 +379,7 @@ pub struct InheritanceGraphStats {
 
 /// Builder for constructing inheritance graphs from parsed contracts
 pub struct InheritanceGraphBuilder<'a> {
+    #[allow(dead_code)]
     symbol_table: &'a SymbolTable,
     graph: InheritanceGraph,
 }

--- a/crates/semantic/src/resolution.rs
+++ b/crates/semantic/src/resolution.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use anyhow::{Result, anyhow};
 
-use ast::{Contract, Function, StateVariable, Expression, Identifier, SourceLocation};
 use crate::symbols::{SymbolTable, Scope, Symbol, SymbolKind};
 use crate::types::{TypeResolver, ResolvedType, TypeCompatibility};
 use crate::inheritance::{InheritanceGraph, InheritanceNode};

--- a/crates/semantic/src/symbols.rs
+++ b/crates/semantic/src/symbols.rs
@@ -168,6 +168,7 @@ struct ScopeInfo {
     /// Parent scope (if any)
     parent: Option<Scope>,
     /// Kind of scope
+    #[allow(dead_code)]
     kind: ScopeKind,
     /// Symbols defined in this scope
     symbols: HashMap<String, Symbol>,
@@ -184,6 +185,7 @@ enum ScopeKind {
     Contract,
     Function,
     Block,
+    #[allow(dead_code)]
     Modifier,
 }
 

--- a/crates/semantic/src/types.rs
+++ b/crates/semantic/src/types.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 use std::fmt;
 use anyhow::{Result, anyhow};
 
-use ast::{TypeName, ElementaryType, Contract, Function, StateVariable, Parameter, SourceLocation};
-use crate::symbols::{SymbolTable, Scope, Symbol, SymbolKind};
+use ast::{TypeName, ElementaryType, Function, StateVariable, SourceLocation};
+use crate::symbols::{SymbolTable, Scope, SymbolKind};
 
 /// Represents a resolved type in the Solidity type system
 #[derive(Debug, Clone, PartialEq)]


### PR DESCRIPTION
  1. Unused imports - Removed or fixed imports that were not being used:
    - std::sync::Arc in database.rs and queries.rs
    - Various AST types in semantic crate
    - HashMap, HashSet where not needed
    - Multiple imports in detectors crate
  2. Unused variables - Prefixed with underscore to indicate intentional:
    - comments in parser arena.rs
    - var and event in parser
    - file_id in database.rs (multiple instances)
    - is_external in IR lowering
    - decimals in IR type conversion
    - cfg, block_id in CFG builder
    - b1_rpo, b2_rpo in dominance analysis
    - block_analyzer in CFG analysis
  3. Dead code warnings - Added #[allow(dead_code)] attributes for:
    - Unused methods in parser (convert_identifier, convert_location)
    - Unused fields in semantic symbols (symbol_table, kind)
    - Unused enum variants (Modifier in ScopeKind)
    - Unused struct fields in various detectors
  4. Unused macros - Added #[allow(unused_macros)] for:
    - impl_detector_base macro in detectors
  5. Unused mut warnings - Removed unnecessary mut qualifiers:
    - ir_function in IR lowering
    - Various variables in dataflow and other crates