### PR TITLE
docs: v1.10.20 ground truth baseline

### DIFF
--- a/docs/baseline/README.md
+++ b/docs/baseline/README.md
@@ -82,7 +82,8 @@ done
 ## Baselines
 
 See individual baseline files:
-- [v1.10.19-baseline.md](v1.10.19-baseline.md) — Current baseline (after FP reduction v5)
+- [v1.10.20-baseline.md](v1.10.20-baseline.md) — Current baseline (after FP reduction v6)
+- [v1.10.19-baseline.md](v1.10.19-baseline.md) — Previous baseline (after FP reduction v5)
 
 ## FP Reduction History
 
@@ -93,3 +94,4 @@ See individual baseline files:
 | v1.10.17 | v3 | 10 | 88 | — | — |
 | v1.10.18 | v4 | 10 | 52 (net -22) | 1,776 | 45 |
 | v1.10.19 | v5 | 20 | 191 | 1,585 | 42 |
+| v1.10.20 | v6 | 30 | 585 | 1,000 | 26 |

--- a/docs/baseline/v1.10.20-baseline.md
+++ b/docs/baseline/v1.10.20-baseline.md
@@ -1,0 +1,142 @@
+# v1.10.20 Baseline — FP Reduction v6
+
+**Date**: 2026-02-06
+**Total Findings**: 1,000 across 18 test targets
+**Clean Contract FPs**: 26 across 5 clean contracts (17 unique detectors)
+
+## Per-Target Findings
+
+| # | Target | Findings |
+|---|--------|----------|
+| 1 | `clean_examples/clean_contract.sol` | 1 |
+| 2 | `fp_benchmarks/safe_amm_pool.sol` | 12 |
+| 3 | `fp_benchmarks/safe_chainlink_consumer.sol` | 5 |
+| 4 | `fp_benchmarks/safe_erc4626_vault.sol` | 3 |
+| 5 | `fp_benchmarks/safe_flash_loan_provider.sol` | 5 |
+| 6 | `basic_vulnerabilities/reentrancy_issues.sol` | 2 |
+| 7 | `basic_vulnerabilities/validation_issues.sol` | 2 |
+| 8 | `vulnerable/` | 56 |
+| 9 | `flash_loans/` | 34 |
+| 10 | `erc4626_vaults/` | 81 |
+| 11 | `price-manipulation/` | 159 |
+| 12 | `cross_chain/` | 40 |
+| 13 | `delegatecall/` | 187 |
+| 14 | `signatures/` | 100 |
+| 15 | `specialized/` | 131 |
+| 16 | `restaking/` | 121 |
+| 17 | `account_abstraction/` | 16 |
+| 18 | `amm_context/` | 45 |
+| | **TOTAL** | **1,000** |
+
+## All Findings by Detector (Top 50)
+
+| Rank | Detector | Count |
+|------|----------|-------|
+| 1 | zk-proof-bypass | 39 |
+| 2 | defi-yield-farming-exploits | 35 |
+| 3 | amm-k-invariant-violation | 35 |
+| 4 | vault-donation-attack | 16 |
+| 5 | price-manipulation-frontrun | 16 |
+| 6 | front-running-mitigation | 16 |
+| 7 | price-oracle-stale | 15 |
+| 8 | oracle-time-window-attack | 15 |
+| 9 | fallback-function-shadowing | 15 |
+| 10 | dos-external-call-loop | 15 |
+| 11 | array-length-mismatch | 15 |
+| 12 | token-transfer-frontrun | 14 |
+| 13 | missing-visibility-modifier | 14 |
+| 14 | token-supply-manipulation | 13 |
+| 15 | restaking-withdrawal-delays | 13 |
+| 16 | missing-transaction-deadline | 13 |
+| 17 | missing-access-modifiers | 13 |
+| 18 | external-calls-loop | 13 |
+| 19 | extcodesize-check-bypass | 13 |
+| 20 | excessive-gas-usage | 13 |
+| 21 | l2-sequencer-dependency | 12 |
+| 22 | transparent-proxy-admin-issues | 11 |
+| 23 | missing-chainid-validation | 11 |
+| 24 | inefficient-storage | 11 |
+| 25 | vault-share-inflation | 10 |
+| 26 | sandwich-resistant-swap | 10 |
+| 27 | proxy-storage-collision | 10 |
+| 28 | price-impact-manipulation | 10 |
+| 29 | missing-zero-address-check | 10 |
+| 30 | missing-eip712-domain | 10 |
+| 31 | mev-priority-gas-auction | 10 |
+| 32 | lrt-share-inflation | 10 |
+| 33 | diamond-storage-collision | 10 |
+| 34 | storage-layout-inheritance-shift | 9 |
+| 35 | signature-malleability | 9 |
+| 36 | sandwich-conditional-swap | 9 |
+| 37 | oracle-update-mev | 9 |
+| 38 | mev-backrun-opportunities | 9 |
+| 39 | l2-fee-manipulation | 9 |
+| 40 | function-selector-clash | 9 |
+| 41 | defi-liquidity-pool-manipulation | 9 |
+| 42 | bundle-inclusion-leak | 9 |
+| 43 | amm-liquidity-manipulation | 9 |
+| 44 | upgrade-event-missing | 8 |
+| 45 | logic-error-patterns | 8 |
+| 46 | l2-data-availability | 8 |
+| 47 | short-address-attack | 7 |
+| 48 | restaking-slashing-conditions | 7 |
+| 49 | post-080-overflow | 7 |
+| 50 | mev-toxic-flow-exposure | 7 |
+
+## Clean Contract FPs (All 26)
+
+| Detector | Count | Affected Contract(s) |
+|----------|-------|---------------------|
+| logic-error-patterns | 3 | safe_amm_pool |
+| unsafe-type-casting | 3 | safe_amm_pool, safe_chainlink_consumer |
+| l2-fee-manipulation | 3 | safe_amm_pool, safe_erc4626_vault, safe_flash_loan |
+| unchecked-math | 2 | safe_amm_pool |
+| l2-sequencer-dependency | 2 | safe_chainlink_consumer |
+| vault-fee-manipulation | 2 | safe_flash_loan |
+| emergency-pause-centralization | 1 | clean_contract |
+| timestamp-manipulation | 1 | safe_amm_pool |
+| redundant-checks | 1 | safe_amm_pool |
+| mev-backrun-opportunities | 1 | safe_amm_pool |
+| mev-priority-gas-auction | 1 | safe_amm_pool |
+| jit-liquidity-extraction | 1 | safe_amm_pool |
+| oracle-staleness-heartbeat | 1 | safe_chainlink_consumer |
+| missing-zero-address-check | 1 | safe_erc4626_vault |
+| unused-state-variables | 1 | safe_erc4626_vault |
+| private-variable-exposure | 1 | safe_flash_loan |
+| governance-parameter-bypass | 1 | safe_flash_loan |
+
+## True Positive Verification
+
+| TP Category | Status | Detector(s) Firing |
+|-------------|--------|-------------------|
+| Reentrancy | PASS | classic-reentrancy, swc105-unprotected-ether-withdrawal |
+| Access Control | PASS | array-bounds-check, logic-error-patterns |
+| Vault Inflation | PASS | vault-share-inflation (5), lrt-share-inflation (3), vault-donation-attack (11) |
+| Chain-ID | PASS | missing-chainid-validation (11), cross-chain-replay (2), cross-chain-replay-protection (2) |
+
+## Change from v1.10.19
+
+| Metric | v1.10.19 | v1.10.20 | Change |
+|--------|----------|----------|--------|
+| Total Findings | 1,585 | 1,000 | -585 (36.9%) |
+| Clean FPs | 42 | 26 | -16 (38.1%) |
+| Unique Detectors | 183 | ~150 | -33 |
+| Detectors Improved | — | 30 | — |
+
+## Top FP Reduction Targets for Next Round
+
+Priority targets based on finding count and clean FP presence:
+
+| Detector | Total Findings | Clean FPs | Priority |
+|----------|---------------|-----------|----------|
+| zk-proof-bypass | 39 | 0 | High — still top volume |
+| defi-yield-farming-exploits | 35 | 0 | High |
+| amm-k-invariant-violation | 35 | 0 | Medium — many may be TPs in AMM contracts |
+| vault-donation-attack | 16 | 0 | Medium — many TPs |
+| front-running-mitigation | 16 | 0 | Medium |
+| fallback-function-shadowing | 15 | 0 | High |
+| dos-external-call-loop | 15 | 0 | High |
+| array-length-mismatch | 15 | 0 | Medium |
+| logic-error-patterns | 8 | 3 | High — 3 clean FPs |
+| l2-fee-manipulation | 9 | 3 | High — 3 clean FPs |
+| unsafe-type-casting | 3 | 3 | High — 100% FP rate in clean |


### PR DESCRIPTION
## Summary

Add v1.10.20 baseline measurements for FP reduction tracking.

- 1,000 total findings across 18 test targets (down from 1,585 in v1.10.19)
- 26 clean contract FPs (down from 42)
- All 4 TP categories verified (reentrancy, access control, vault inflation, chain-ID)
- Updated FP reduction history table
- Priority targets identified for next round