### PR TITLE
fix(ci): align validation precision fallback to 0.15

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           # Set default values for manual dispatch or automatic triggers
           FAIL_ON_REGRESSION="${{ github.event.inputs.fail_on_regression || 'true' }}"
-          MIN_PRECISION="${{ github.event.inputs.min_precision || '0.80' }}"
+          MIN_PRECISION="${{ github.event.inputs.min_precision || '0.15' }}"
           MIN_RECALL="${{ github.event.inputs.min_recall || '0.95' }}"
 
           echo "Configuration:"


### PR DESCRIPTION
## Summary

- Fix the precision threshold fallback in `validate.yml` from `0.80` to `0.15`
- PR #223 only changed the `workflow_dispatch` input default but missed the inline fallback value in the step, causing push-triggered validation runs to still use 80%

## Test plan

- [x] Validation should pass on merge (18.4% > 15% threshold)