### PR TITLE
fix: add pull-requests write permission to validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,6 +30,10 @@ on:
         default: '0.95'
         type: string
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Summary

- Add `pull-requests: write` permission to the Detector Validation workflow
- Fixes the "Comment on PR" step which was failing with `HttpError: Resource not accessible by integration`

## Root cause

The `actions/github-script@v7` step that posts validation results as PR comments requires write access to pull requests. Without explicit permissions, GitHub defaults to read-only, causing the step to fail.

## Test plan

- [ ] Detector Validation workflow completes all steps including "Comment on PR"