### PR TITLE
docs: fix stale contract counts and version references

### DIFF
--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -36,9 +36,9 @@ When tightening detectors to reduce false positives, we need to verify:
 
 | Metric | Count |
 |--------|-------|
-| Total contracts | 117 |
+| Total contracts | 122 |
 | Clean/secure contracts | 43 |
-| Vulnerable contracts | 74 |
+| Vulnerable contracts | 79 |
 | Expected true positives | 149 |
 | Parse error contracts | 0 |
 | Vulnerability categories | 26 |

--- a/docs/baseline/README.md
+++ b/docs/baseline/README.md
@@ -1,6 +1,6 @@
 # Ground Truth Baseline Documentation
 
-This directory contains baseline measurements for the SolidityDefend false positive reduction process. These baselines track findings across 18 test targets (117 individual contracts) and are used to measure the effectiveness of each FP reduction round.
+This directory contains baseline measurements for the SolidityDefend false positive reduction process. These baselines track findings across 18 test targets (122 individual contracts) and are used to measure the effectiveness of each FP reduction round.
 
 ## Ground Truth Coverage
 

--- a/docs/detectors/README.md
+++ b/docs/detectors/README.md
@@ -1,6 +1,6 @@
 # SolidityDefend Detector Documentation
 
-Complete reference for all security detectors in SolidityDefend v2.0.3.
+Complete reference for all security detectors in SolidityDefend v2.0.8.
 
 **Last Updated:** 2026-02-16
 **Version:** v2.0.8


### PR DESCRIPTION
## Summary

Fixes stale metrics in documentation that were not updated during the ground truth expansion (PR #244).

- **VALIDATION.md**: Total contracts 117 → 122, vulnerable contracts 74 → 79 (matches ground truth v1.4.0)
- **baseline/README.md**: Contract count 117 → 122 in description text
- **detectors/README.md**: Version reference v2.0.3 → v2.0.8 in header description

## Test plan

- [x] Documentation-only changes, no code changes
- [x] All metrics now consistent across docs and ground truth