### PR TITLE
fix: resolve CI formatting check failure

### DIFF
--- a/crates/detectors/src/external.rs
+++ b/crates/detectors/src/external.rs
@@ -375,7 +375,11 @@ mod tests {
         let detector = UncheckedCallDetector::new();
         let arena = ast::AstArena::new();
 
-        let loc = ast::SourceLocation::new("t.sol".into(), ast::Position::start(), ast::Position::start());
+        let loc = ast::SourceLocation::new(
+            "t.sol".into(),
+            ast::Position::start(),
+            ast::Position::start(),
+        );
         let addr = arena.alloc(ast::Expression::Identifier(ast::Identifier::new(
             arena.alloc_str("recipient"),
             loc.clone(),
@@ -398,7 +402,11 @@ mod tests {
         let detector = UncheckedCallDetector::new();
         let arena = ast::AstArena::new();
 
-        let loc = ast::SourceLocation::new("t.sol".into(), ast::Position::start(), ast::Position::start());
+        let loc = ast::SourceLocation::new(
+            "t.sol".into(),
+            ast::Position::start(),
+            ast::Position::start(),
+        );
         let addr = arena.alloc(ast::Expression::Identifier(ast::Identifier::new(
             arena.alloc_str("recipient"),
             loc.clone(),
@@ -429,7 +437,11 @@ mod tests {
         let detector = UncheckedCallDetector::new();
         let arena = ast::AstArena::new();
 
-        let loc = ast::SourceLocation::new("t.sol".into(), ast::Position::start(), ast::Position::start());
+        let loc = ast::SourceLocation::new(
+            "t.sol".into(),
+            ast::Position::start(),
+            ast::Position::start(),
+        );
         let addr = arena.alloc(ast::Expression::Identifier(ast::Identifier::new(
             arena.alloc_str("shareholders"),
             loc.clone(),

--- a/crates/parser/src/arena.rs
+++ b/crates/parser/src/arena.rs
@@ -947,8 +947,12 @@ impl<'arena> ArenaParser<'arena> {
             // any function that uses `+=`, `-=`, etc. — including the canonical
             // CEI-violation pattern `balances[msg.sender] -= amount;`.
             pt::Expression::AssignAdd(_, left, right) => {
-                let left_expr = self.arena.alloc(self.convert_expression(left, source, file_path)?);
-                let right_expr = self.arena.alloc(self.convert_expression(right, source, file_path)?);
+                let left_expr = self
+                    .arena
+                    .alloc(self.convert_expression(left, source, file_path)?);
+                let right_expr = self
+                    .arena
+                    .alloc(self.convert_expression(right, source, file_path)?);
                 Ok(Expression::Assignment {
                     left: left_expr,
                     operator: AssignmentOperator::AddAssign,
@@ -957,8 +961,12 @@ impl<'arena> ArenaParser<'arena> {
                 })
             }
             pt::Expression::AssignSubtract(_, left, right) => {
-                let left_expr = self.arena.alloc(self.convert_expression(left, source, file_path)?);
-                let right_expr = self.arena.alloc(self.convert_expression(right, source, file_path)?);
+                let left_expr = self
+                    .arena
+                    .alloc(self.convert_expression(left, source, file_path)?);
+                let right_expr = self
+                    .arena
+                    .alloc(self.convert_expression(right, source, file_path)?);
                 Ok(Expression::Assignment {
                     left: left_expr,
                     operator: AssignmentOperator::SubAssign,
@@ -967,8 +975,12 @@ impl<'arena> ArenaParser<'arena> {
                 })
             }
             pt::Expression::AssignMultiply(_, left, right) => {
-                let left_expr = self.arena.alloc(self.convert_expression(left, source, file_path)?);
-                let right_expr = self.arena.alloc(self.convert_expression(right, source, file_path)?);
+                let left_expr = self
+                    .arena
+                    .alloc(self.convert_expression(left, source, file_path)?);
+                let right_expr = self
+                    .arena
+                    .alloc(self.convert_expression(right, source, file_path)?);
                 Ok(Expression::Assignment {
                     left: left_expr,
                     operator: AssignmentOperator::MulAssign,
@@ -977,8 +989,12 @@ impl<'arena> ArenaParser<'arena> {
                 })
             }
             pt::Expression::AssignDivide(_, left, right) => {
-                let left_expr = self.arena.alloc(self.convert_expression(left, source, file_path)?);
-                let right_expr = self.arena.alloc(self.convert_expression(right, source, file_path)?);
+                let left_expr = self
+                    .arena
+                    .alloc(self.convert_expression(left, source, file_path)?);
+                let right_expr = self
+                    .arena
+                    .alloc(self.convert_expression(right, source, file_path)?);
                 Ok(Expression::Assignment {
                     left: left_expr,
                     operator: AssignmentOperator::DivAssign,
@@ -987,8 +1003,12 @@ impl<'arena> ArenaParser<'arena> {
                 })
             }
             pt::Expression::AssignModulo(_, left, right) => {
-                let left_expr = self.arena.alloc(self.convert_expression(left, source, file_path)?);
-                let right_expr = self.arena.alloc(self.convert_expression(right, source, file_path)?);
+                let left_expr = self
+                    .arena
+                    .alloc(self.convert_expression(left, source, file_path)?);
+                let right_expr = self
+                    .arena
+                    .alloc(self.convert_expression(right, source, file_path)?);
                 Ok(Expression::Assignment {
                     left: left_expr,
                     operator: AssignmentOperator::ModAssign,
@@ -997,8 +1017,12 @@ impl<'arena> ArenaParser<'arena> {
                 })
             }
             pt::Expression::AssignAnd(_, left, right) => {
-                let left_expr = self.arena.alloc(self.convert_expression(left, source, file_path)?);
-                let right_expr = self.arena.alloc(self.convert_expression(right, source, file_path)?);
+                let left_expr = self
+                    .arena
+                    .alloc(self.convert_expression(left, source, file_path)?);
+                let right_expr = self
+                    .arena
+                    .alloc(self.convert_expression(right, source, file_path)?);
                 Ok(Expression::Assignment {
                     left: left_expr,
                     operator: AssignmentOperator::AndAssign,
@@ -1007,8 +1031,12 @@ impl<'arena> ArenaParser<'arena> {
                 })
             }
             pt::Expression::AssignOr(_, left, right) => {
-                let left_expr = self.arena.alloc(self.convert_expression(left, source, file_path)?);
-                let right_expr = self.arena.alloc(self.convert_expression(right, source, file_path)?);
+                let left_expr = self
+                    .arena
+                    .alloc(self.convert_expression(left, source, file_path)?);
+                let right_expr = self
+                    .arena
+                    .alloc(self.convert_expression(right, source, file_path)?);
                 Ok(Expression::Assignment {
                     left: left_expr,
                     operator: AssignmentOperator::OrAssign,
@@ -1017,8 +1045,12 @@ impl<'arena> ArenaParser<'arena> {
                 })
             }
             pt::Expression::AssignXor(_, left, right) => {
-                let left_expr = self.arena.alloc(self.convert_expression(left, source, file_path)?);
-                let right_expr = self.arena.alloc(self.convert_expression(right, source, file_path)?);
+                let left_expr = self
+                    .arena
+                    .alloc(self.convert_expression(left, source, file_path)?);
+                let right_expr = self
+                    .arena
+                    .alloc(self.convert_expression(right, source, file_path)?);
                 Ok(Expression::Assignment {
                     left: left_expr,
                     operator: AssignmentOperator::XorAssign,
@@ -1027,8 +1059,12 @@ impl<'arena> ArenaParser<'arena> {
                 })
             }
             pt::Expression::AssignShiftLeft(_, left, right) => {
-                let left_expr = self.arena.alloc(self.convert_expression(left, source, file_path)?);
-                let right_expr = self.arena.alloc(self.convert_expression(right, source, file_path)?);
+                let left_expr = self
+                    .arena
+                    .alloc(self.convert_expression(left, source, file_path)?);
+                let right_expr = self
+                    .arena
+                    .alloc(self.convert_expression(right, source, file_path)?);
                 Ok(Expression::Assignment {
                     left: left_expr,
                     operator: AssignmentOperator::ShiftLeftAssign,
@@ -1037,8 +1073,12 @@ impl<'arena> ArenaParser<'arena> {
                 })
             }
             pt::Expression::AssignShiftRight(_, left, right) => {
-                let left_expr = self.arena.alloc(self.convert_expression(left, source, file_path)?);
-                let right_expr = self.arena.alloc(self.convert_expression(right, source, file_path)?);
+                let left_expr = self
+                    .arena
+                    .alloc(self.convert_expression(left, source, file_path)?);
+                let right_expr = self
+                    .arena
+                    .alloc(self.convert_expression(right, source, file_path)?);
                 Ok(Expression::Assignment {
                     left: left_expr,
                     operator: AssignmentOperator::ShiftRightAssign,


### PR DESCRIPTION
## Summary

- Lines in `arena.rs` (compound assignment parsing) and `external.rs` (unchecked-call detector tests) exceeded the `max_width = 100` limit in `rustfmt.toml`
- This caused `cargo fmt -- --check` to exit non-zero in the CI pipeline (run [#26344656233](https://github.com/AdvancedBlockchainSecurity/SolidityDefend/actions/runs/26344656233))
- Applied `cargo fmt` to wrap the offending lines

## Changes

| File | Change |
|------|--------|
| `crates/parser/src/arena.rs` | Wrap chained `.arena.alloc(self.convert_expression(...))` calls across 10 compound assignment arms |
| `crates/detectors/src/external.rs` | Wrap `SourceLocation::new(...)` constructors in 3 test functions |

## Test plan

- [x] `cargo fmt -- --check` exits 0 (no diffs)
- [x] `cargo test -p detectors --lib` — 444 passed, 0 failed
- [x] No functional changes — formatting only