### PR TITLE
release: v2.0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.9"
+version = "2.0.10"
 edition = "2021"
 authors = ["SolidityDefend Team"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

Version bump to **2.0.10** for the recall regression fix release.

### What's in v2.0.10

**6 bugs fixed** across parser, IR, and 4 detectors that were causing recall regressions introduced by FP-reduction commits in v2.0.3–v2.0.8:

| # | Component | Bug |
|---|-----------|-----|
| 1 | `reentrancy.rs` | `is_pull_payment_pattern` matched the canonical CEI-violation pattern |
| 2 | `access_control.rs` | 18 ownership-change verbs missing from admin-only list |
| 3 | `external.rs` | `.call{value:}` wrapper not peeled — discarded-tuple call never recognized |
| 4 | `arena.rs` | All compound assignments (`+=`, `-=`, etc.) fell to `Literal("0")` catch-all |
| 5 | `delegatecall_return_ignored.rs` | `return success` treated as validation |
| 6 | `bridge_token_minting.rs` | Empty modifiers trusted as access control |
| IR | `lowering.rs` | Call-options wrapper not peeled for dataflow path |

### Validation

| Metric | v2.0.9 | v2.0.10 |
|--------|--------|---------|
| Ground truth recall | 147/149 (98.7%) | **149/149 (100%)** |
| VulnerableVault_2 | 1/4 | **4/4** |
| Cargo tests | 422 | **444** (+22 regression tests) |
| FPs on clean contracts | 0 | 0 |
| External validation | — | 63 contracts, 222 findings, 0 errors |

## Test plan

- [x] `cargo test -p detectors --lib` — 444 passed
- [x] Ground truth: 149/149 (100%)
- [x] CI formatting check passes
- [x] No regressions on clean contracts