### PR TITLE
fix(detectors): reduce false positives across 8 detectors (v2.0.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to SolidityDefend will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.13] - 2026-07-11
+
+### Fixed
+- **False-positive reduction across 8 detectors** — audit against heavily-audited safe code (OpenZeppelin v5.x, 247 files; simplified real protocols, 13 files) where every finding is a false positive by construction. OpenZeppelin false positives dropped 40 → 17 (−58%) with no recall regression (vulnerable-corpus findings 334 → 332; ground-truth suite green). (ADV-204)
+  - `missing-access-modifiers`: normalize OpenZeppelin `Context._msgSender()` → `msg.sender` so caller-identity heuristics apply; recognize `_checkAuthorized`/named-unauthorized reverts; skip `super.<fn>()` override delegations; skip proposal-state- and signature-gated executors; treat caller-owned `burn`/`setOperator` as self-scoped (10 OZ FPs → 0)
+  - `array-bounds-check`: only flag when ≥2 array parameters are actually index-accessed in the function body, sparing thin forwarders that delegate length validation to a callee (8 OZ FPs → 2)
+  - `dos-unbounded-operation`: match `for (`/`while(` keywords instead of the bare substring `for` (which matched "before" in comments); skip `.length` write-targets in the parameter-bounded check (2 OZ FPs → 0)
+  - `erc20-approve-race`: downgrade Medium → Info (the SWC-114 race is inherent to the ERC-20/6909 standard, incl. OpenZeppelin v5); skip proxy contracts; require the approve body to write an allowance; relax `increaseAllowance`/`decreaseAllowance` arity for ERC-6909
+  - `proxy-storage-collision`: gate `_delegate(`/`_fallback()` proxy signals on an actual `delegatecall` (fixes governance `Votes._delegate` misfire); add ERC-7201 namespaced-storage early-out (2 OZ FPs → 0)
+  - `unchecked-external-call`: recognize OpenZeppelin `Address.verifyCallResult` as a return-value check (1 OZ FP → 0)
+  - `centralization-risk`: require an actual owner/admin gate before flagging arbitrary token transfers, and fix an `||`/`&&` operator-precedence bug that fired on ownerless contracts (1 OZ FP → 0)
+  - `block-dependency`: exempt `block.timestamp` comparisons against deadline/expiry-named operands (the standard EIP-2612 expiry check) (1 OZ FP → 0)
+
+---
+
 ## [2.0.9] - 2026-02-28
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.12"
+version = "2.0.13"
 edition = "2021"
 authors = ["SolidityDefend Team"]
 license = "MIT OR Apache-2.0"

--- a/crates/detectors/src/access_control.rs
+++ b/crates/detectors/src/access_control.rs
@@ -588,7 +588,11 @@ impl MissingModifiersDetector {
 
         let source_lines: Vec<&str> = ctx.source_code.lines().collect();
         if start < source_lines.len() && end < source_lines.len() {
-            source_lines[start..=end].join("\n")
+            // FP Reduction: normalize OZ Context's _msgSender() to msg.sender so
+            // caller-identity heuristics apply uniformly.
+            source_lines[start..=end]
+                .join("\n")
+                .replace("_msgSender()", "msg.sender")
         } else {
             String::new()
         }
@@ -618,6 +622,7 @@ impl MissingModifiersDetector {
             || lower.contains("_checkrole")
             || lower.contains("_checksender")
             || lower.contains("_checkauthority")
+            || lower.contains("_checkauthorized")
             || lower.contains("_requireowner")
             || lower.contains("_requireadmin");
 
@@ -631,6 +636,15 @@ impl MissingModifiersDetector {
             || lower.contains("revert onlyadmin")
             || lower.contains("revert onlyguardian")
             || lower.contains("revert notguardian");
+
+        // Check for named custom-error unauthorized reverts, e.g.
+        // `revert OwnableUnauthorizedAccount(msg.sender)` or `revert AccessDenied()`.
+        let has_named_unauthorized_revert = lower.lines().any(|l| {
+            l.contains("revert")
+                && (l.contains("unauthorized")
+                    || l.contains("accessdenied")
+                    || l.contains("notallowed"))
+        });
 
         // Check for governance role checks (guardian, pauser, keeper, operator)
         let has_governance_check = lower.contains("require(msg.sender == guardian")
@@ -658,6 +672,7 @@ impl MissingModifiersDetector {
             || has_revert_unauthorized
             || has_governance_check
             || has_tx_origin_check
+            || has_named_unauthorized_revert
     }
 
     /// Phase 15 FP Reduction: Check if function has owner check
@@ -802,10 +817,17 @@ impl MissingModifiersDetector {
             }
         }
 
-        // Pattern: function uses msg.sender as first argument to external calls
+        // Pattern: function uses msg.sender as the subject of external calls
         // AND modifies no other state. This covers DeFi withdraw patterns like
-        // aToken.burn(msg.sender, to, amount) where the caller's balance is affected.
-        if func_source.contains(".burn(msg.sender,") || func_source.contains(".burn(msg.sender)") {
+        // aToken.burn(msg.sender, to, amount) where the caller's balance is affected,
+        // as well as caller-scoped operator/approval updates.
+        let collapsed_lower = func_source.replace(['\n', '\r', ' '], "").to_lowercase();
+        if (collapsed_lower.contains("burn(msg.sender,")
+            || collapsed_lower.contains("burn(msg.sender)")
+            || collapsed_lower.contains("_setoperator(msg.sender,")
+            || collapsed_lower.contains("_approve(msg.sender,"))
+            && !self.sends_to_arbitrary_address(func_source)
+        {
             return true;
         }
 
@@ -961,6 +983,35 @@ impl MissingModifiersDetector {
 
         has_target_param
     }
+
+    /// FP Reduction: `execute` functions intentionally permissionless because auth
+    /// comes from proposal state (Governor) or signature verification (ERC-2771),
+    /// not caller identity.
+    fn is_state_or_signature_gated_executor(
+        &self,
+        function_name: &str,
+        func_source: &str,
+        ctx: &AnalysisContext<'_>,
+    ) -> bool {
+        if !function_name.to_lowercase().starts_with("execute") {
+            return false;
+        }
+        let body = func_source.to_lowercase();
+        let src = ctx.source_code.to_lowercase();
+        let governor_gate = body.contains("_validatestatebitmap")
+            || body.contains("proposalstate.")
+            || ((src.contains("governor") || src.contains("igovernor"))
+                && body.contains("proposal"));
+        let has_sig_machinery = src.contains("ecrecover")
+            || src.contains("ecdsa")
+            || src.contains("signermatch")
+            || src.contains("istrustedforwarder");
+        let signature_gate = has_sig_machinery
+            && (body.contains("request")
+                || body.contains("signature")
+                || body.contains("_validate"));
+        governor_gate || signature_gate
+    }
 }
 
 impl Detector for MissingModifiersDetector {
@@ -1098,6 +1149,12 @@ impl Detector for MissingModifiersDetector {
                     continue;
                 }
 
+                // FP Reduction: overrides that delegate to super.<fn>() inherit the parent's
+                // access control (e.g. AccessControl.grantRole carries onlyRole(getRoleAdmin(role))).
+                if func_source.contains(&format!("super.{}(", function.name.name)) {
+                    continue;
+                }
+
                 // Phase 15 FP Reduction: Check if function is in a contract with Ownable
                 // and has require(msg.sender == owner) check
                 if self.has_owner_check(&func_source, &ctx.source_code) {
@@ -1147,6 +1204,14 @@ impl Detector for MissingModifiersDetector {
                 // not the forwarder. Example: transferOwnership(address target, ...)
                 // that just calls target.call(abi.encodeWithSignature("transferOwnership(address)", ...))
                 if self.is_forwarder_function(&func_source, function) {
+                    continue;
+                }
+
+                // FP Reduction: Skip execute() functions gated by proposal state
+                // (Governor) or signature verification (ERC-2771 forwarders) rather
+                // than caller identity.
+                if self.is_state_or_signature_gated_executor(function.name.name, &func_source, ctx)
+                {
                     continue;
                 }
 

--- a/crates/detectors/src/centralization_risk.rs
+++ b/crates/detectors/src/centralization_risk.rs
@@ -187,10 +187,15 @@ impl CentralizationRiskDetector {
         let has_selfdestruct =
             contract_source.contains("selfdestruct") || contract_source.contains("suicide");
 
-        let has_arbitrary_token_transfer = contract_source.contains("transferFrom(address(this)")
-            || contract_source.contains(".transfer(owner")
-            || contract_source.contains(".transfer(msg.sender")
-                && contract_source.contains("onlyOwner");
+        // Only "owner drains tokens" if there is actually an owner/admin-gated path.
+        let has_owner_gate = contract_source.contains("onlyOwner")
+            || contract_source.contains("onlyAdmin")
+            || contract_source.contains("msg.sender == owner")
+            || contract_source.contains("msg.sender == admin");
+        let has_arbitrary_token_transfer = has_owner_gate
+            && (contract_source.contains("transferFrom(address(this)")
+                || contract_source.contains(".transfer(owner")
+                || contract_source.contains(".transfer(msg.sender"));
 
         // Phase 16 FN Recovery: Check for governance-specific centralization
         // Governance contracts have unique centralization risks even with OZ Ownable

--- a/crates/detectors/src/dos_unbounded_operation.rs
+++ b/crates/detectors/src/dos_unbounded_operation.rs
@@ -164,7 +164,9 @@ impl DosUnboundedOperationDetector {
         }
 
         // Pattern 1: Loop over unbounded array
-        let has_loop = func_source.contains("for") || func_source.contains("while");
+        let has_loop = ["for (", "for(", "while (", "while("]
+            .iter()
+            .any(|kw| func_source.contains(kw));
         let loops_over_storage =
             has_loop && (func_source.contains(".length") || func_source.contains("[]"));
 
@@ -481,6 +483,13 @@ impl DosUnboundedOperationDetector {
                 .collect();
 
             if ident.is_empty() {
+                continue;
+            }
+
+            // Skip assignments TO `.length` (e.g. a struct field write like
+            // `plan.length = ...`). A write target is not a loop bound.
+            let after = length_refs[i + 1].trim_start();
+            if after.starts_with('=') && !after.starts_with("==") {
                 continue;
             }
 

--- a/crates/detectors/src/erc20_approve_race.rs
+++ b/crates/detectors/src/erc20_approve_race.rs
@@ -23,7 +23,9 @@ impl Erc20ApproveRaceDetector {
                 "ERC-20 Approve Race Condition".to_string(),
                 "Detects ERC-20 approve functions vulnerable to front-running race conditions (SWC-114)".to_string(),
                 vec![DetectorCategory::Logic, DetectorCategory::DeFi],
-                Severity::Medium,
+                // Info: the SWC-114 approve race is inherent to the ERC-20 standard itself,
+                // not an implementation bug — mitigation is caller-side.
+                Severity::Info,
             ),
         }
     }
@@ -76,6 +78,11 @@ impl Detector for Erc20ApproveRaceDetector {
             return Ok(findings);
         }
 
+        // FP Reduction: Skip proxy contracts — approve() there merely forwards to the impl.
+        if crate::utils::is_proxy_contract(ctx) {
+            return Ok(findings);
+        }
+
         // FP Reduction: Skip files in directories with dedicated detectors
         // Restaking tokens have standard approve() but are covered by restaking detectors
         // Critical vulnerability files are focused on other patterns (permit, create2, etc.)
@@ -113,8 +120,10 @@ impl Detector for Erc20ApproveRaceDetector {
                 .create_finding(ctx, consolidated_msg, first_line, 0, 40)
                 .with_cwe(362)
                 .with_fix_suggestion(
-                    "Use increaseAllowance/decreaseAllowance pattern, \
-                    or require current allowance == 0 before changes."
+                    "The approve race is inherent to ERC-20/ERC-6909 (SWC-114); \
+                    mitigation is caller-side: set the allowance to 0 before setting \
+                    a new value, or use ERC-2612 permit. Note OpenZeppelin v5 removed \
+                    increaseAllowance/decreaseAllowance."
                         .to_string(),
                 );
             findings.push(finding);
@@ -134,14 +143,14 @@ impl Erc20ApproveRaceDetector {
     fn has_increase_allowance(&self, ctx: &AnalysisContext) -> bool {
         ctx.get_functions()
             .iter()
-            .any(|func| func.name.name == "increaseAllowance" && func.parameters.len() == 2)
+            .any(|func| func.name.name == "increaseAllowance")
     }
 
     /// Checks if contract has decreaseAllowance function
     fn has_decrease_allowance(&self, ctx: &AnalysisContext) -> bool {
         ctx.get_functions()
             .iter()
-            .any(|func| func.name.name == "decreaseAllowance" && func.parameters.len() == 2)
+            .any(|func| func.name.name == "decreaseAllowance")
     }
 
     /// Checks if this appears to be an ERC20 contract
@@ -172,6 +181,13 @@ impl Erc20ApproveRaceDetector {
 
         // Only report if this looks like an ERC20 contract
         if !self.is_erc20_contract(ctx) {
+            return None;
+        }
+
+        // The approve body must actually write an allowance (directly or via _approve).
+        let writes_allowance = func_source.contains("_approve(")
+            || (func_source.contains("allowance") && func_source.contains('='));
+        if !writes_allowance {
             return None;
         }
 
@@ -234,6 +250,6 @@ mod tests {
     fn test_detector_properties() {
         let detector = Erc20ApproveRaceDetector::new();
         assert_eq!(detector.name(), "ERC-20 Approve Race Condition");
-        assert_eq!(detector.default_severity(), Severity::Medium);
+        assert_eq!(detector.default_severity(), Severity::Info);
     }
 }

--- a/crates/detectors/src/external.rs
+++ b/crates/detectors/src/external.rs
@@ -362,7 +362,8 @@ impl UncheckedCallDetector {
             || lower.contains("if(!sent")
             || lower.contains("assert(success")
             || lower.contains("assert(ok")
-            || lower.contains("assert(sent");
+            || lower.contains("assert(sent")
+            || lower.contains("verifycallresult");
 
         has_success_var && has_success_require
     }

--- a/crates/detectors/src/proxy_storage_collision.rs
+++ b/crates/detectors/src/proxy_storage_collision.rs
@@ -169,6 +169,11 @@ impl ProxyStorageCollisionDetector {
         let contract_source_owned = crate::utils::get_contract_source(ctx);
         let contract_source = &contract_source_owned;
 
+        // FP Reduction: ERC-7201 namespaced storage exists to PREVENT collisions.
+        if contract_source.contains("@custom:storage-location erc7201:") {
+            return None;
+        }
+
         // FP Reduction: Skip OZ Upgradeable base contracts (properly managed storage)
         let source_lower = contract_source.to_lowercase();
         if (source_lower.contains("@openzeppelin/contracts-upgradeable")
@@ -231,22 +236,24 @@ impl ProxyStorageCollisionDetector {
             || name_lower == "erc1967proxy"
             || name_lower == "transparentupgradeableproxy";
 
+        // FP Reduction: Check for delegatecall in actual code (not comments)
+        // and exclude staticcall-only contracts (read-only delegation)
+        let has_delegatecall =
+            self.has_in_code(source, "delegatecall") && !self.is_staticcall_only(source);
+
         // Strong proxy signals (EIP-1967 or explicit proxy patterns)
         // FP Reduction: Require function-like patterns (_fallback(), _delegate())
-        // not just variable names containing "_fallback"
+        // not just variable names containing "_fallback". _delegate( is also the
+        // governance vote-delegation function name (OZ Votes), so both signals
+        // additionally require an actual delegatecall in the contract.
         let has_proxy_patterns = source.contains("IMPLEMENTATION_SLOT")
             || source.contains("_IMPLEMENTATION_SLOT")
             || source.contains("_ADMIN_SLOT")
             || source.contains("eip1967")
             || source.contains("EIP1967")
-            || source.contains("_fallback()")
-            || source.contains("_delegate(")
+            || (source.contains("_fallback()") && has_delegatecall)
+            || (source.contains("_delegate(") && has_delegatecall)
             || (source.contains("implementation()") && source.contains("delegatecall"));
-
-        // FP Reduction: Check for delegatecall in actual code (not comments)
-        // and exclude staticcall-only contracts (read-only delegation)
-        let has_delegatecall =
-            self.has_in_code(source, "delegatecall") && !self.is_staticcall_only(source);
 
         // A contract is a proxy if:
         // 1. It has proxy in name AND delegatecall, OR

--- a/crates/detectors/src/timestamp.rs
+++ b/crates/detectors/src/timestamp.rs
@@ -177,7 +177,9 @@ impl BlockDependencyDetector {
                     else_branch,
                     ..
                 } => {
-                    if self.expression_uses_timestamp(condition) {
+                    if self.expression_uses_timestamp(condition)
+                        && !Self::is_deadline_comparison(condition)
+                    {
                         return true;
                     }
                     if let ast::Statement::Block(b) = then_branch {
@@ -268,6 +270,37 @@ impl BlockDependencyDetector {
             }
             _ => false,
         }
+    }
+
+    /// block.timestamp compared against a deadline/expiry value is the standard
+    /// safe pattern (EIP-2612 permit, order expiry) — not flagged.
+    fn is_deadline_comparison(expr: &ast::Expression<'_>) -> bool {
+        if let ast::Expression::BinaryOperation {
+            operator,
+            left,
+            right,
+            ..
+        } = expr
+        {
+            use ast::BinaryOperator::{Greater, GreaterEqual, Less, LessEqual};
+            if matches!(operator, Greater | GreaterEqual | Less | LessEqual) {
+                return Self::names_deadline(left) || Self::names_deadline(right);
+            }
+        }
+        false
+    }
+
+    fn names_deadline(expr: &ast::Expression<'_>) -> bool {
+        let name = match expr {
+            ast::Expression::Identifier(id) => id.name.to_lowercase(),
+            ast::Expression::MemberAccess { member, .. } => member.name.to_lowercase(),
+            _ => return false,
+        };
+        name.contains("deadline")
+            || name.contains("expir")
+            || name.contains("validuntil")
+            || name.contains("validafter")
+            || name.contains("endtime")
     }
 }
 

--- a/crates/detectors/src/validation/array_bounds.rs
+++ b/crates/detectors/src/validation/array_bounds.rs
@@ -899,6 +899,16 @@ impl ArrayBoundsDetector {
             }
             // Phase 10: Check if function body already has length validation
             let func_source = self.get_function_source(function, ctx);
+            // FP Reduction (Gate 1): Only flag when at least two array params are actually
+            // index-accessed in THIS function. Thin entry points that forward arrays to an
+            // internal implementation rely on the callee for length validation.
+            let indexed_count = array_params
+                .iter()
+                .filter(|(name, _)| Self::is_param_index_accessed(&func_source, name))
+                .count();
+            if indexed_count < 2 {
+                return findings;
+            }
             if self.has_length_validation(&func_source, &array_params) {
                 return findings; // Already has validation
             }
@@ -949,6 +959,25 @@ impl ArrayBoundsDetector {
             }
         }
 
+        false
+    }
+
+    /// Is `name` index-accessed (`name[...]`) in the function source? Word-boundary
+    /// aware (won't match `tokenIds[` for param `ds`), and skips `.name[` (struct member).
+    fn is_param_index_accessed(func_source: &str, name: &str) -> bool {
+        let pattern = format!("{}[", name);
+        let mut from = 0;
+        while let Some(rel) = func_source[from..].find(&pattern) {
+            let abs = from + rel;
+            let ok = func_source[..abs]
+                .chars()
+                .next_back()
+                .map_or(true, |c| !c.is_alphanumeric() && c != '_' && c != '.');
+            if ok {
+                return true;
+            }
+            from = abs + pattern.len();
+        }
         false
     }
 

--- a/crates/detectors/tests/test_front_running.rs
+++ b/crates/detectors/tests/test_front_running.rs
@@ -16,7 +16,7 @@ fn test_erc20_approve_race_metadata() {
 
     assert_eq!(detector.id().0, "erc20-approve-race");
     assert_eq!(detector.name(), "ERC-20 Approve Race Condition");
-    assert_eq!(detector.default_severity(), Severity::Medium);
+    assert_eq!(detector.default_severity(), Severity::Info);
     assert!(detector.is_enabled());
 
     let categories = detector.categories();
@@ -64,11 +64,12 @@ fn test_detector_categories_unique() {
 }
 
 #[test]
-fn test_all_detectors_medium_severity() {
+fn test_all_detectors_expected_severity() {
     let detector1 = Erc20ApproveRaceDetector::new();
     let detector3 = AllowanceToctouDetector::new();
 
-    assert_eq!(detector1.default_severity(), Severity::Medium);
+    // erc20-approve-race is Info: the race is inherent to the ERC-20 standard (SWC-114)
+    assert_eq!(detector1.default_severity(), Severity::Info);
     assert_eq!(detector3.default_severity(), Severity::Medium);
 }
 

--- a/docs/DETECTOR-TYPES.md
+++ b/docs/DETECTOR-TYPES.md
@@ -362,7 +362,7 @@ Legacy list of 209 security detectors organized by category.
 **Total: 15 detectors**
 
 - **`erc1155-batch-validation`** - ERC-1155 Batch Validation (Medium)
-- **`erc20-approve-race`** - ERC-20 Approve Race Condition (Medium)
+- **`erc20-approve-race`** - ERC-20 Approve Race Condition (Info)
 - **`erc20-infinite-approval`** - Infinite Approval Risk (Low)
 - **`erc20-transfer-return-bomb`** - ERC-20 Transfer Return Bomb (Medium)
 - **`erc4337-entrypoint-trust`** - ERC-4337 Untrusted EntryPoint (Critical)

--- a/docs/detectors/all_detectors.json
+++ b/docs/detectors/all_detectors.json
@@ -242,7 +242,7 @@
       "id": "erc20-approve-race",
       "name": "ERC-20 Approve Race Condition",
       "description": "Detects ERC-20 approve functions vulnerable to front-running race conditions (SWC-114)",
-      "severity": "medium",
+      "severity": "info",
       "categories": [
         "Logic",
         "DeFi"

--- a/docs/detectors/front-running/erc20-approve-race.md
+++ b/docs/detectors/front-running/erc20-approve-race.md
@@ -1,7 +1,7 @@
 # ERC20 Approve Race Condition
 
 **Detector ID:** `erc20-approve-race`
-**Severity:** Medium
+**Severity:** Info
 **Category:** Front-Running, ERC Standards, MEV
 **CWE:** CWE-362 (Concurrent Execution using Shared Resource with Improper Synchronization)
 **SWC:** SWC-114 (Transaction Order Dependence)
@@ -61,7 +61,7 @@ This creates a **check-time-of-use (TOCTOU)** race condition where the spender c
 
 ### Estimated Impact
 
-- **Severity**: Medium (requires specific conditions and MEV infrastructure)
+- **Severity**: Info (the SWC-114 race is inherent to the ERC-20/6909 standard — every compliant `approve` is affected, including OpenZeppelin v5 which removed `increase/decreaseAllowance`; reported informationally rather than as a per-token defect)
 - **Exploitability**: Moderate (requires mempool access and gas optimization)
 - **Affected Tokens**: Thousands of ERC20 tokens without safe alternatives
 - **Financial Risk**: Potential loss of entire approved amount plus new approval

--- a/tests/validation/ground_truth.json
+++ b/tests/validation/ground_truth.json
@@ -1856,7 +1856,7 @@
             300
           ],
           "label": "true_positive",
-          "severity": "medium",
+          "severity": "info",
           "description": "Standard approve race condition - no safe alternatives",
           "vulnerability_type": "approve-race"
         }


### PR DESCRIPTION
## Summary

False-positive reduction across 8 detectors, found by auditing SolidityDefend against heavily-audited safe code (OpenZeppelin v5.x — 247 files; simplified real protocols — 13 files), where every finding is a false positive by construction.

**Result:** OpenZeppelin false positives dropped **40 → 17 (−58%)** with **no recall regression** — vulnerable-corpus findings held 334 → 332 and the ground-truth suite stays green.

## Detectors fixed

| Detector | Root cause | Fix |
|---|---|---|
| `missing-access-modifiers` | blind to OZ `_msgSender()`; no `super.<fn>()` / state-gate awareness | normalize `_msgSender()`; recognize `_checkAuthorized`/named reverts; skip super-delegations, state/sig-gated executors, self-scoped `burn`/`setOperator` |
| `array-bounds-check` | flagged forwarders that never index arrays | require ≥2 array params actually index-accessed |
| `dos-unbounded-operation` | `contains("for")` matched "before" in a comment | match `for (`/`while(`; skip `.length` write-targets |
| `erc20-approve-race` | fires on every compliant approve (incl. OZ v5) | Medium → Info; skip proxies; require allowance body |
| `proxy-storage-collision` | treated governance `_delegate(` as a proxy signal | gate on actual `delegatecall`; ERC-7201 early-out |
| `unchecked-external-call` | missed OZ `Address.verifyCallResult` | add to success-check allow-list |
| `centralization-risk` | fired with no owner present; `\|\|`/`&&` precedence bug | require owner gate; fix precedence |
| `block-dependency` | flagged the EIP-2612 `block.timestamp > deadline` check | exempt deadline/expiry comparisons |

Bumps workspace version 2.0.12 → 2.0.13.

## Ship phases

- Changelog ✓ (`## [2.0.13]` + cross-repo ledger)
- Security audit ✓ (PASS — no secrets/deps/network/injection; static-analysis logic only)
- Tests ✓ (545 detector + 33 validation, 0 failures; rebuilt at 2.0.13)
- Docs ✓ (detector catalog + per-detector severity synced)
- Standards ✓ (conventional commits, semver, no new deps, no attribution)

## Follow-ups

- ADV-205 — proper detector-invocation FP regression guards for the 8 fixes
- 10 remaining detectors with proposed-but-unapplied fixes; deferred `array-bounds` Gate 2; 6 OZ files that fail to parse

Refs: ADV-204