### PR TITLE
fix(detectors): restore array-bounds parallel-array recall (v2.0.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to SolidityDefend will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.14] - 2026-07-12
+
+### Fixed
+- **`array-bounds-check` recall regression from 2.0.13** — the Gate 1 tightening (require array params to be index-accessed) was too aggressive: it suppressed the classic parallel-array bug where a loop is bounded by one array's `.length` and indexes a *different* array (e.g. `for (i < users.length) { … isActive[i] … }`) because only one array used `[i]` syntax. Gate 1 now flags when ≥1 array param is index-accessed AND ≥2 params participate in the iteration (index access or a `name.length` loop bound). Thin forwarders (no index access) stay suppressed; OpenZeppelin false positives remain at 17. (ADV-214)
+
 ## [2.0.13] - 2026-07-11
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "2.0.13"
+version = "2.0.14"
 edition = "2021"
 authors = ["SolidityDefend Team"]
 license = "MIT OR Apache-2.0"

--- a/crates/detectors/src/validation/array_bounds.rs
+++ b/crates/detectors/src/validation/array_bounds.rs
@@ -899,14 +899,26 @@ impl ArrayBoundsDetector {
             }
             // Phase 10: Check if function body already has length validation
             let func_source = self.get_function_source(function, ctx);
-            // FP Reduction (Gate 1): Only flag when at least two array params are actually
-            // index-accessed in THIS function. Thin entry points that forward arrays to an
-            // internal implementation rely on the callee for length validation.
+            // FP Reduction (Gate 1): Flag only when the arrays are actually used
+            // together in a way that can mismatch. Require (a) at least one array
+            // param index-accessed (`name[i]`), AND (b) at least two params
+            // participating in the iteration — where "participating" means either
+            // index-accessed or used as a `name.length` loop bound. This catches the
+            // classic parallel-array bug (loop bounded by `a.length` that indexes
+            // `b[i]` with no length check) while still sparing thin forwarders, which
+            // never index the arrays at all and defer validation to a callee.
             let indexed_count = array_params
                 .iter()
                 .filter(|(name, _)| Self::is_param_index_accessed(&func_source, name))
                 .count();
-            if indexed_count < 2 {
+            let participating = array_params
+                .iter()
+                .filter(|(name, _)| {
+                    Self::is_param_index_accessed(&func_source, name)
+                        || func_source.contains(&format!("{}.length", name))
+                })
+                .count();
+            if indexed_count < 1 || participating < 2 {
                 return findings;
             }
             if self.has_length_validation(&func_source, &array_params) {


### PR DESCRIPTION
## Summary

Follow-up to ADV-204. Comprehensive recall testing against the vulnerable corpus surfaced **one lost true positive** from the 2.0.13 array-bounds Gate 1 tightening.

`VulnerableCommonPatterns.updateBalances(address[] users, uint256[] newBalances, bool[] isActive)` loops `for (i < users.length) { if (isActive[i]) … }` with no length check — a real out-of-bounds bug. Gate 1 suppressed it because only **one** array (`isActive`) used `[i]` syntax (`users` participates via `.length`, `newBalances` is unused).

## Fix

Gate 1 now flags when **≥1** array param is index-accessed AND **≥2** params participate in the iteration (index access or a `name.length` loop bound). Forwarders with zero index access stay suppressed.

## Verification

- `updateBalances` TP restored; `submitBatchBid` FP (unused second array, empty loop) stays suppressed
- OpenZeppelin safe corpus unchanged at **17** (array-bounds still 2 — no new FPs)
- All 8 ADV-204 detectors fire on per-detector positive vulnerable fixtures
- Full workspace suite green (50 groups, 0 failures); detector 545/0; ground-truth passing

Bumps 2.0.13 → 2.0.14.

## Ship phases
Changelog ✓ · Security audit ✓ (logic-only, no new surface) · Tests ✓ · Docs (N/A — no severity/catalog change) · Standards ✓

Refs: ADV-214