### PR TITLE
chore(ci): repo-wide cargo fmt to unblock rustfmt --check gate

### DIFF
--- a/crates/detectors/src/access_control.rs
+++ b/crates/detectors/src/access_control.rs
@@ -1873,9 +1873,7 @@ mod tests {
         "#;
         let findings = detect_findings(&detector, source);
         assert!(
-            findings
-                .iter()
-                .any(|f| f.message.contains("setOracle")),
+            findings.iter().any(|f| f.message.contains("setOracle")),
             "setOracle without an access modifier should fire"
         );
         assert!(
@@ -1906,9 +1904,7 @@ mod tests {
         "#;
         let findings = detect_findings(&detector, source);
         assert!(
-            findings
-                .iter()
-                .any(|f| f.message.contains("slashOperator")),
+            findings.iter().any(|f| f.message.contains("slashOperator")),
             "slashOperator without an access modifier should fire"
         );
     }

--- a/crates/detectors/src/external.rs
+++ b/crates/detectors/src/external.rs
@@ -189,10 +189,11 @@ impl UncheckedCallDetector {
                     }
                 }
                 ast::Statement::VariableDeclaration {
-                    initial_value: Some(ast::Expression::FunctionCall {
-                        function: call_expr,
-                        ..
-                    }),
+                    initial_value:
+                        Some(ast::Expression::FunctionCall {
+                            function: call_expr,
+                            ..
+                        }),
                     ..
                 } => {
                     if self.is_external_call(call_expr) {
@@ -223,10 +224,7 @@ impl UncheckedCallDetector {
                 }
                 // Tuple destructure: (bool success, ) = addr.call{value:}("")
                 // Parser represents as Expression(Assignment { right: FunctionCall })
-                ast::Statement::Expression(ast::Expression::Assignment {
-                    right,
-                    ..
-                }) => {
+                ast::Statement::Expression(ast::Expression::Assignment { right, .. }) => {
                     if let ast::Expression::FunctionCall {
                         function: call_expr,
                         ..
@@ -268,8 +266,7 @@ impl UncheckedCallDetector {
                         func_source,
                     );
                 }
-                ast::Statement::For { body, .. }
-                | ast::Statement::While { body, .. } => {
+                ast::Statement::For { body, .. } | ast::Statement::While { body, .. } => {
                     self.recurse_into_statement(body, ctx, findings, function, func_source);
                 }
                 ast::Statement::If {
@@ -279,7 +276,13 @@ impl UncheckedCallDetector {
                 } => {
                     self.recurse_into_statement(then_branch, ctx, findings, function, func_source);
                     if let Some(else_stmt) = else_branch {
-                        self.recurse_into_statement(else_stmt, ctx, findings, function, func_source);
+                        self.recurse_into_statement(
+                            else_stmt,
+                            ctx,
+                            findings,
+                            function,
+                            func_source,
+                        );
                     }
                 }
                 ast::Statement::TryStatement {

--- a/crates/detectors/src/governance.rs
+++ b/crates/detectors/src/governance.rs
@@ -638,9 +638,9 @@ impl SignatureReplayDetector {
             "nonces[",
             "usednonces[",
             "usedsignatures[",
-            "usedsignatures",   // catches: mapping(...) public usedSignatures; declarations
+            "usedsignatures", // catches: mapping(...) public usedSignatures; declarations
             "usedhashes[",
-            "usedhashes",       // catches: mapping(...) public usedHashes; declarations
+            "usedhashes", // catches: mapping(...) public usedHashes; declarations
             "invalidatenonce",
             "_usenonce",
             "nonce++",
@@ -782,9 +782,16 @@ impl SignatureReplayDetector {
             // Note: "used" alone (without other context) is checked; false positives are
             // filtered by the contract-level check below.
             let nonce_patterns = [
-                "nonce", "nonces", "_nonce", "counter", "replay",
-                "usedhash", "usedsig", "usednonce",
-                "!initialized", "require(!initialized",
+                "nonce",
+                "nonces",
+                "_nonce",
+                "counter",
+                "replay",
+                "usedhash",
+                "usedsig",
+                "usednonce",
+                "!initialized",
+                "require(!initialized",
             ];
             let has_nonce_protection = nonce_patterns
                 .iter()

--- a/crates/detectors/src/registry.rs
+++ b/crates/detectors/src/registry.rs
@@ -480,9 +480,7 @@ impl DetectorRegistry {
         self.register(Arc::new(
             crate::dos_external_call_loop::DosExternalCallLoopDetector::new(),
         ));
-        self.register(Arc::new(
-            crate::gas_griefing::GasGriefingDetector::new(),
-        ));
+        self.register(Arc::new(crate::gas_griefing::GasGriefingDetector::new()));
 
         // Oracle & Price Manipulation
         self.register(Arc::new(
@@ -495,9 +493,7 @@ impl DetectorRegistry {
         ));
 
         // Block Dependency
-        self.register(Arc::new(
-            crate::timestamp::BlockDependencyDetector::new(),
-        ));
+        self.register(Arc::new(crate::timestamp::BlockDependencyDetector::new()));
 
         // Type Safety
         self.register(Arc::new(

--- a/crates/detectors/src/timestamp.rs
+++ b/crates/detectors/src/timestamp.rs
@@ -81,7 +81,6 @@ impl Detector for BlockDependencyDetector {
         }
 
         for function in ctx.get_functions() {
-
             if let Some((has_dependency, manipulation_type)) =
                 self.has_timestamp_dependency(function, ctx)
             {
@@ -265,9 +264,7 @@ impl BlockDependencyDetector {
                     || self.expression_uses_timestamp(true_expression)
                     || self.expression_uses_timestamp(false_expression)
             }
-            ast::Expression::IndexAccess { base, .. } => {
-                self.expression_uses_timestamp(base)
-            }
+            ast::Expression::IndexAccess { base, .. } => self.expression_uses_timestamp(base),
             _ => false,
         }
     }
@@ -365,7 +362,9 @@ mod tests {
             "lottery using block.timestamp for winner selection should fire"
         );
         assert!(
-            findings.iter().all(|f| f.detector_id.0 == "block-dependency"),
+            findings
+                .iter()
+                .all(|f| f.detector_id.0 == "block-dependency"),
             "all findings should come from block-dependency"
         );
     }

--- a/crates/detectors/src/utils.rs
+++ b/crates/detectors/src/utils.rs
@@ -1359,8 +1359,7 @@ pub fn is_test_contract(ctx: &AnalysisContext) -> bool {
     // Only match CLEAR test patterns with word boundaries or exact names
 
     // Contract name patterns indicating test/mock - check word boundaries
-    let is_test_name =
-        name == "test"
+    let is_test_name = name == "test"
         || ctx.contract.name.name.starts_with("Test")
         || name.ends_with("_test")
         // Clear mock prefixes/suffixes with proper boundaries


### PR DESCRIPTION
## What

Applies `cargo fmt --all` to clear long-standing rustfmt drift that has been failing the `CI/CD Pipeline` **Build and Test → Check formatting** step (`cargo fmt --all --check`) on `main`.

## Why

CI has been red across multiple commits — including the merge `314d22d`, which predates the ADV-204 detector work — because `cargo fmt --check` failed. This blocks the tag-triggered release of **v2.0.14**. The failure is the formatting gate, not the rust-toolchain action (toolchain step succeeds; the fmt step is the failure). `Detector Validation` passes independently.

## Change

Pure rustfmt reflow across six detector files:
- **ADV-204-touched:** `access_control.rs`, `external.rs`, `timestamp.rs`
- **pre-existing drift (untouched by ADV-204):** `governance.rs`, `registry.rs`, `utils.rs`

Reflow only — brace/paren line-wrapping, trailing-comma normalization, one blank-line removal, match-arm collapsing. No logic changes.

## Verification

- `cargo fmt --all --check` — clean
- `cargo build --release` — clean
- `cargo test -p detectors` — **545 passed / 0 failed**
- Live recall-fixture scan — all 8 ADV-204 detectors still fire, including the recovered `array-bounds-check` TP
- Whitespace-stripped file hashes identical modulo trailing commas

## Phases
changelog ✓ · security ✓ (formatting-only, no secrets/deps/surface) · tests ✓ · standards ✓

Refs: ADV-218