### PR TITLE
fix(ci): bump Docker builder base to rust:1.88 for icu MSRV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage build for SolidityDefend
 # Builder stage
-FROM rust:1.85-slim-bookworm AS builder
+FROM rust:1.88-slim-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## What
Bumps `Dockerfile:3` builder base from `rust:1.85-slim-bookworm` to `rust:1.88-slim-bookworm`.

## Why
The `CI/CD Pipeline` **Docker Build** job (runs only on push to `main`) has been failing — including on commits that predate the ADV-204/214/218 detector work. Transitive deps now require rustc 1.86:
```
icu_properties@2.2.0 requires rustc 1.86
icu_provider@2.2.0    requires rustc 1.86
idna_adapter@1.2.2    requires rustc 1.86
```
`cargo build --release` exited 101 in the builder stage. The Dockerfile resolves deps fresh (no committed `Cargo.lock`), so the base image must carry a compiler >= 1.86.

## Not a release regression
`release.yml` builds native binaries, not the Docker image; v2.0.14 published successfully with all 5 targets. This only restores the Docker image artifact.

## Verification
Docker Build is gated to push-on-main and cannot run on a PR, so it will be verified on the post-merge main run. PR CI still exercises Build and Test / Regression / Coverage / Validate Detectors. Runtime stage unchanged (`debian:bookworm-slim`, non-root).

Refs: ADV-219